### PR TITLE
Fix typo in podcast script title

### DIFF
--- a/data/scripts.ts
+++ b/data/scripts.ts
@@ -3,7 +3,7 @@ import { PodcastScript } from '../types/script';
 export const podcastScripts: PodcastScript[] = [
   {
     podcastId: '10',
-    title: 'Learn to Use AI: Taming Inconsistent AI Images,
+    title: 'Learn to Use AI: Taming Inconsistent AI Images',
     content: `[PLACEHOLDER: Add the full script content for the JSON Formatting for AI Image Generation podcast here]
 
 This should include:


### PR DESCRIPTION
Corrected a missing closing quote in the title field of the podcastScripts array in scripts.ts.